### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -90,7 +90,7 @@ const authenticateAPIKey = (req, res, next) => {
   const validAPIKeys = (process.env.API_KEYS || '').split(',').filter(Boolean);
 
   if (!validAPIKeys.includes(apiKey)) {
-    logger.warn(`Invalid API key attempted: ${apiKey.substring(0, 8)}...`);
+    logger.warn('Invalid API key attempted.');
     return next(ErrorFactory.unauthorized('Invalid API key'));
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/waleedcodes/Commity/security/code-scanning/1](https://github.com/waleedcodes/Commity/security/code-scanning/1)

The logging statement on line 93 should be changed to avoid outputting any part of the API key, even as a substring. Instead, we can log that an invalid API key attempt occurred, possibly with additional non-sensitive context (such as a request ID, remote IP—if safe and GDPR-compliant, etc.), but never echoing or including any part of the API key itself. The fix is to replace the log message with a message that does *not* reference any part of the sensitive key.  
Make this change only on the affected logger.warn call. No new imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
