### PR TITLE
fix: Remove bufferMaxEntries option from mongoose connection settings

### DIFF
--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -12,7 +12,6 @@ const connectDB = async () => {
       serverSelectionTimeoutMS: 5000, // Keep trying to send operations for 5 seconds
       socketTimeoutMS: 45000, // Close sockets after 45 seconds of inactivity
       bufferCommands: false, // Disable mongoose buffering
-      bufferMaxEntries: 0, // Disable mongoose buffering
     };
 
     const conn = await mongoose.connect(mongoURI, options);


### PR DESCRIPTION
This pull request makes a small change to the MongoDB connection configuration in `backend/src/config/database.js`. The change removes the deprecated `bufferMaxEntries` option from the connection options, ensuring compatibility with newer versions of Mongoose.