### PR TITLE
feat: update import paths for user analytics hooks in UserProfile component

### DIFF
--- a/frontend/app/components/Navigation.js
+++ b/frontend/app/components/Navigation.js
@@ -2,10 +2,10 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Button } from '../ui/Button';
-import { Input } from '../ui/Input';
-import { Avatar, AvatarFallback, AvatarImage } from '../ui/Avatar';
-import { cn } from '../../lib/utils';
+import { Button } from './ui/Button';
+import { Input } from './ui/Input';
+import { Avatar, AvatarFallback, AvatarImage } from './ui/Avatar';
+import { cn } from "@/lib/utils"
 
 export default function Navigation() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);

--- a/frontend/app/components/ui/Avatar.js
+++ b/frontend/app/components/ui/Avatar.js
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as AvatarPrimitive from "@radix-ui/react-avatar"
-import { cn } from "../../lib/utils"
+import { cn } from "@/lib/utils"
 
 const Avatar = React.forwardRef(({ className, ...props }, ref) => (
   <AvatarPrimitive.Root

--- a/frontend/app/components/ui/Badge.js
+++ b/frontend/app/components/ui/Badge.js
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { cva } from "class-variance-authority"
-import { cn } from "../../lib/utils"
+import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",

--- a/frontend/app/components/ui/Button.js
+++ b/frontend/app/components/ui/Button.js
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva } from "class-variance-authority"
-import { cn } from "../../lib/utils"
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",

--- a/frontend/app/components/ui/Card.js
+++ b/frontend/app/components/ui/Card.js
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { cn } from "../../lib/utils"
+import { cn } from "@/lib/utils"
 
 const Card = React.forwardRef(({ className, ...props }, ref) => (
   <div

--- a/frontend/app/components/ui/Input.js
+++ b/frontend/app/components/ui/Input.js
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { cn } from "../../lib/utils"
+import { cn } from "@/lib/utils"
 
 const Input = React.forwardRef(({ className, type, ...props }, ref) => {
   return (

--- a/frontend/app/components/ui/Loading.js
+++ b/frontend/app/components/ui/Loading.js
@@ -1,0 +1,56 @@
+export const LoadingSpinner = ({ size = 'md', className = '' }) => {
+  const sizeClasses = {
+    sm: 'h-4 w-4',
+    md: 'h-8 w-8', 
+    lg: 'h-12 w-12'
+  };
+
+  return (
+    <div className={`animate-spin rounded-full border-2 border-gray-300 border-t-indigo-600 ${sizeClasses[size]} ${className}`}></div>
+  );
+};
+
+export const LoadingCard = ({ className = '' }) => (
+  <div className={`bg-white dark:bg-gray-800 rounded-lg shadow p-6 animate-pulse ${className}`}>
+    <div className="flex items-center space-x-4">
+      <div className="w-12 h-12 bg-gray-300 dark:bg-gray-600 rounded-full"></div>
+      <div className="flex-1 space-y-2">
+        <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-3/4"></div>
+        <div className="h-3 bg-gray-300 dark:bg-gray-600 rounded w-1/2"></div>
+      </div>
+    </div>
+  </div>
+);
+
+export const LoadingTable = ({ rows = 5, cols = 4 }) => (
+  <div className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+    <div className="animate-pulse">
+      {/* Header */}
+      <div className="bg-gray-50 dark:bg-gray-700 px-6 py-3 border-b border-gray-200 dark:border-gray-600">
+        <div className="flex space-x-4">
+          {Array.from({ length: cols }).map((_, i) => (
+            <div key={i} className="h-4 bg-gray-300 dark:bg-gray-600 rounded flex-1"></div>
+          ))}
+        </div>
+      </div>
+      
+      {/* Rows */}
+      {Array.from({ length: rows }).map((_, rowIndex) => (
+        <div key={rowIndex} className="px-6 py-4 border-b border-gray-200 dark:border-gray-600 last:border-b-0">
+          <div className="flex space-x-4">
+            {Array.from({ length: cols }).map((_, colIndex) => (
+              <div key={colIndex} className="h-4 bg-gray-300 dark:bg-gray-600 rounded flex-1"></div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export const LoadingChart = ({ className = '' }) => (
+  <div className={`bg-white dark:bg-gray-800 rounded-lg shadow p-6 animate-pulse ${className}`}>
+    <div className="h-4 bg-gray-300 dark:bg-gray-600 rounded w-1/3 mb-4"></div>
+    <div className="h-64 bg-gray-300 dark:bg-gray-600 rounded"></div>
+  </div>
+);

--- a/frontend/app/profile/[username]/page.js
+++ b/frontend/app/profile/[username]/page.js
@@ -5,7 +5,8 @@ import { Button } from '../../components/ui/Button';
 import { Badge } from '../../components/ui/Badge';
 import { Avatar, AvatarFallback, AvatarImage } from '../../components/ui/Avatar';
 import { useUser, useUserActivity, useUserRepositories } from '../../hooks/useUsers';
-import { useUserAnalytics, useUserRanking } from '../../hooks/useLeaderboard';
+import { useUserAnalytics } from '../../hooks/useAnalytics';
+import { useUserRanking } from '../../hooks/useLeaderboard';
 import { formatNumber, formatDate, formatRelativeTime, getLanguageColor } from '../../utils/helpers';
 
 export default function UserProfile({ params }) {

--- a/frontend/app/profile/[username]/page.js
+++ b/frontend/app/profile/[username]/page.js
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useState, use } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/Card';
 import { Button } from '../../components/ui/Button';
 import { Badge } from '../../components/ui/Badge';
@@ -10,7 +10,7 @@ import { useUserRanking } from '../../hooks/useLeaderboard';
 import { formatNumber, formatDate, formatRelativeTime, getLanguageColor } from '../../utils/helpers';
 
 export default function UserProfile({ params }) {
-  const { username } = params;
+  const { username } = use(params);
   const [activeTab, setActiveTab] = useState('overview');
 
   const { user, loading: userLoading, refreshUser } = useUser(username);


### PR DESCRIPTION
This pull request focuses on simplifying and standardizing import paths throughout the frontend codebase, especially for UI components and utility functions. Additionally, it introduces new loading indicator components for improved user experience during data fetching.

**Import Path Refactoring:**

* Updated all UI component imports (`Button`, `Input`, `Avatar`, `Badge`, `Card`) in `frontend/app/components/Navigation.js` and their respective component files to use relative paths starting from the current directory or the root alias (`@/lib/utils`), replacing previous relative paths. This ensures consistency and easier maintainability of import statements. [[1]](diffhunk://#diff-1ebb438ee036ef3109cde588e05a61d8975addd796a3c05e37624e4a1a25ce70L5-R8) [[2]](diffhunk://#diff-1cf030782da46dedc33f74a25feabb9ca85bd3aa9a44d940d9607b7265641939L3-R3) [[3]](diffhunk://#diff-ab1a2442d22effd192a537916e14f18684a360cab6bede69a1b6fa026515c317L3-R3) [[4]](diffhunk://#diff-8dd31d9110fb9d8660432a4f54ddd75c5e9db772d6e4441086a5ec3db89d693fL4-R4) [[5]](diffhunk://#diff-7e2329eb156c5c15397aac60881d54f7345120e2f07938d117928a7bdc162148L2-R2) [[6]](diffhunk://#diff-31d800b94b35f2b36a8a7ac5f668db70280553bbe823696180545ec7b50ca2e2L2-R2)

**New Loading Components:**

* Added new loading UI components: `LoadingSpinner`, `LoadingCard`, `LoadingTable`, and `LoadingChart` in `frontend/app/components/ui/Loading.js`, providing reusable skeletons and spinners for various loading states in the application.

**Analytics Hook Refactor:**

* Refactored the analytics import in `frontend/app/profile/[username]/page.js` to use `useUserAnalytics` from `hooks/useAnalytics` instead of `hooks/useLeaderboard`, clarifying the separation of concerns between analytics and leaderboard data. ([frontend/app/profile/[username]/page.jsL8-R9](diffhunk://#diff-a3519b26d95c5ebcda3b453b642aa508bc8f49ea6c49af69b60c9d669d1a056aL8-R9))