### PR TITLE
fix: update MongoDB URI in environment configuration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,7 +6,7 @@ NODE_ENV=development
 GITHUB_TOKEN=your_github_personal_access_token_here
 
 # Database Configuration
-MONGODB_URI=mongodb://localhost:27017/github-analytics
+MONGODB_URI=mongodb://localhost:27017/name_of_your_database
 
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=900000


### PR DESCRIPTION
This pull request updates the example MongoDB connection string in the `backend/.env.example` file to use a placeholder database name, making it clearer for users to customize their environment configuration.

* Updated the value of `MONGODB_URI` to use `name_of_your_database` instead of a hardcoded database name in `backend/.env.example`.