### PR TITLE
feat: update analytics periods to use new formats; add legacy support for backward compatibility

### DIFF
--- a/backend/src/config/constants.js
+++ b/backend/src/config/constants.js
@@ -21,11 +21,17 @@ const APP_CONSTANTS = {
   
   // Analytics periods
   ANALYTICS_PERIODS: {
-    DAILY: 'daily',
-    WEEKLY: 'weekly',
-    MONTHLY: 'monthly',
-    YEARLY: 'yearly',
+    DAILY: '1d',
+    WEEKLY: '7d', 
+    MONTHLY: '30d',
+    QUARTERLY: '90d',
+    YEARLY: '365d',
     ALL_TIME: 'all_time',
+    // Legacy support
+    LEGACY_DAILY: 'daily',
+    LEGACY_WEEKLY: 'weekly',
+    LEGACY_MONTHLY: 'monthly',
+    LEGACY_YEARLY: 'yearly',
   },
   
   // GitHub event types

--- a/backend/src/controllers/analyticsController.js
+++ b/backend/src/controllers/analyticsController.js
@@ -492,6 +492,7 @@ class AnalyticsController {
             };
             break;
           case 'monthly':
+          case '30d':
             groupBy_id = {
               year: { $year: '$date' },
               month: { $month: '$date' }
@@ -537,7 +538,7 @@ class AnalyticsController {
         // Format results with date strings
         const formattedResults = results.map(item => {
           let dateStr;
-          if (groupBy === 'monthly') {
+          if (groupBy === 'monthly' || groupBy === '30d') {
             dateStr = `${item._id.year}-${String(item._id.month).padStart(2, '0')}`;
           } else if (groupBy === 'weekly') {
             const date = new Date(item._id.year, 0, 1 + (item._id.week - 1) * 7);

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -88,8 +88,8 @@ const queryParamsSchema = Joi.object({
 // Analytics query schema
 const analyticsQuerySchema = Joi.object({
   period: Joi.string()
-    .valid(...Object.values(ANALYTICS_PERIODS))
-    .default(ANALYTICS_PERIODS.MONTHLY),
+    .valid(...Object.values(ANALYTICS_PERIODS), '1d', '7d', '30d', '90d', '365d')
+    .default('30d'),
   startDate: Joi.date().iso().optional(),
   endDate: Joi.date().iso().min(Joi.ref('startDate')).optional(),
   username: Joi.string().pattern(REGEX.GITHUB_USERNAME).optional(),

--- a/backend/src/models/Analytics.js
+++ b/backend/src/models/Analytics.js
@@ -17,7 +17,7 @@ const analyticsSchema = new mongoose.Schema({
   // Time period for analytics
   period: {
     type: String,
-    enum: ['daily', 'weekly', 'monthly', 'yearly'],
+    enum: ['1d', '7d', '30d', '90d', '365d', 'all_time', 'daily', 'weekly', 'monthly', 'yearly'], // Support both new and legacy formats
     required: true,
     index: true,
   },
@@ -313,7 +313,7 @@ analyticsSchema.statics.getAnalyticsByPeriod = function(userId, period, startDat
   return this.find(query).sort({ startDate: -1 });
 };
 
-analyticsSchema.statics.getTopPerformers = function(period = 'monthly', metric = 'contributions.total', limit = 10) {
+analyticsSchema.statics.getTopPerformers = function(period = '30d', metric = 'contributions.total', limit = 10) {
   return this.aggregate([
     { $match: { period } },
     { $sort: { [metric]: -1, startDate: -1 } },
@@ -347,7 +347,7 @@ analyticsSchema.statics.calculateTrends = function(userId, metric = 'contributio
   return this.aggregate([
     { $match: { 
       userId: new mongoose.Types.ObjectId(userId),
-      period: 'monthly'
+      period: '30d'
     }},
     { $sort: { startDate: -1 } },
     { $limit: periods },


### PR DESCRIPTION
This pull request updates the analytics period handling across the backend to use consistent, duration-based string identifiers (like `'30d'` for monthly) instead of legacy names. It also adds support for legacy period names to maintain backward compatibility. The changes affect constants, validation, database schema, and analytics logic to ensure uniformity and easier future maintenance.

**Analytics period standardization:**

* Updated `APP_CONSTANTS.ANALYTICS_PERIODS` in `constants.js` to use duration-based identifiers (e.g., `'1d'`, `'7d'`, `'30d'`, `'90d'`, `'365d'`) and added legacy period names for backward compatibility.
* Modified the analytics model schema in `Analytics.js` to accept both new and legacy period formats in the `period` field.

**Controller and logic updates:**

* Updated `AnalyticsController` logic to treat `'30d'` as equivalent to `'monthly'` for grouping and formatting results. [[1]](diffhunk://#diff-02225097f8e9dd6869c3684d18fa2987f0c633474a402cf4f58662cc81e5844dR495) [[2]](diffhunk://#diff-02225097f8e9dd6869c3684d18fa2987f0c633474a402cf4f58662cc81e5844dL540-R541)
* Changed static methods in the analytics model (`getTopPerformers`, `calculateTrends`) to use `'30d'` as the default period instead of `'monthly'`. [[1]](diffhunk://#diff-e0b4aeb0730809b1c5d9c87b49731618a48247acfa68e649aa352b3b9918095bL316-R316) [[2]](diffhunk://#diff-e0b4aeb0730809b1c5d9c87b49731618a48247acfa68e649aa352b3b9918095bL350-R350)

**Validation improvements:**

* Enhanced analytics query validation in `validation.js` to accept both new duration-based and legacy period identifiers, with `'30d'` as the default.